### PR TITLE
Add context to validation function

### DIFF
--- a/projects/ngx-permissions/src/lib/directive/permissions.directive.ts
+++ b/projects/ngx-permissions/src/lib/directive/permissions.directive.ts
@@ -39,14 +39,15 @@ export class NgxPermissionsDirective implements OnInit, OnDestroy, OnChanges  {
 
     @Input() ngxPermissionsOnlyAuthorisedStrategy: string | StrategyFunction;
     @Input() ngxPermissionsOnlyUnauthorisedStrategy: string | StrategyFunction;
+    @Input() ngxPermissionsOnlyContext: any;
 
     @Input() ngxPermissionsExceptUnauthorisedStrategy: string | StrategyFunction;
     @Input() ngxPermissionsExceptAuthorisedStrategy: string | StrategyFunction;
+    @Input() ngxPermissionsExceptContext: any;
 
     @Input() ngxPermissionsUnauthorisedStrategy: string | StrategyFunction;
     @Input() ngxPermissionsAuthorisedStrategy: string | StrategyFunction;
 
-    @Input() ngxPermissionsContext: any;
 
     @Output() permissionsAuthorized = new EventEmitter();
     @Output() permissionsUnauthorized = new EventEmitter();
@@ -128,7 +129,7 @@ export class NgxPermissionsDirective implements OnInit, OnDestroy, OnChanges  {
     private validateExceptAndOnlyPermissions(): void {
         Promise
             .all([
-              this.permissionsService.hasPermission(this.ngxPermissionsExcept),
+              this.permissionsService.hasPermission(this.ngxPermissionsExcept, this.ngxPermissionsExceptContext),
               this.rolesService.hasOnlyRoles(this.ngxPermissionsExcept)
             ])
             .then(([hasPermission, hasRole]) => {
@@ -155,7 +156,7 @@ export class NgxPermissionsDirective implements OnInit, OnDestroy, OnChanges  {
     private validateOnlyPermissions(): void {
         Promise
             .all([
-                this.permissionsService.hasPermission(this.ngxPermissionsOnly, this.ngxPermissionsContext),
+                this.permissionsService.hasPermission(this.ngxPermissionsOnly, this.ngxPermissionsOnlyContext),
                 this.rolesService.hasOnlyRoles(this.ngxPermissionsOnly)
             ])
             .then(([hasPermissions, hasRoles]) => {

--- a/projects/ngx-permissions/src/lib/directive/permissions.directive.ts
+++ b/projects/ngx-permissions/src/lib/directive/permissions.directive.ts
@@ -46,6 +46,8 @@ export class NgxPermissionsDirective implements OnInit, OnDestroy, OnChanges  {
     @Input() ngxPermissionsUnauthorisedStrategy: string | StrategyFunction;
     @Input() ngxPermissionsAuthorisedStrategy: string | StrategyFunction;
 
+    @Input() ngxPermissionsContext: any;
+
     @Output() permissionsAuthorized = new EventEmitter();
     @Output() permissionsUnauthorized = new EventEmitter();
 
@@ -152,7 +154,10 @@ export class NgxPermissionsDirective implements OnInit, OnDestroy, OnChanges  {
 
     private validateOnlyPermissions(): void {
         Promise
-            .all([this.permissionsService.hasPermission(this.ngxPermissionsOnly), this.rolesService.hasOnlyRoles(this.ngxPermissionsOnly)])
+            .all([
+                this.permissionsService.hasPermission(this.ngxPermissionsOnly, this.ngxPermissionsContext),
+                this.rolesService.hasOnlyRoles(this.ngxPermissionsOnly)
+            ])
             .then(([hasPermissions, hasRoles]) => {
                 if (hasPermissions || hasRoles) {
                     this.handleAuthorisedPermission(this.ngxPermissionsOnlyThen || this.ngxPermissionsThen || this.templateRef);

--- a/projects/ngx-permissions/src/lib/model/permissions-router-data.model.ts
+++ b/projects/ngx-permissions/src/lib/model/permissions-router-data.model.ts
@@ -14,6 +14,7 @@ export interface NgxRedirectToNavigationParameters {
 
 export declare type OnlyFn = (route: ActivatedRouteSnapshot | Route, state?: RouterStateSnapshot) => string | string[];
 export declare type ExceptFn = (route: ActivatedRouteSnapshot | Route, state?: RouterStateSnapshot) => string | string[];
+export declare type ContextFn = (route: ActivatedRouteSnapshot | Route, state?: RouterStateSnapshot) => string | string[];
 
 export declare type RedirectTo =
     string

--- a/projects/ngx-permissions/src/lib/model/permissions-router-data.model.ts
+++ b/projects/ngx-permissions/src/lib/model/permissions-router-data.model.ts
@@ -4,6 +4,7 @@ export interface NgxPermissionsRouterData {
     only?: string | string[] | OnlyFn;
     except?: string | string[] | ExceptFn;
     redirectTo?: RedirectTo | RedirectToFn;
+    context?: any;
 }
 
 export interface NgxRedirectToNavigationParameters {
@@ -23,6 +24,7 @@ export declare type RedirectToFn =
 
 export declare type NavigationCommandsFn = (route: ActivatedRouteSnapshot | Route, state?: RouterStateSnapshot) => any[];
 export declare type NavigationExtrasFn = (route: ActivatedRouteSnapshot | Route, state?: RouterStateSnapshot) => NavigationExtras;
-export declare type ValidationFn = ((name?: string, store?: any) => Promise<void | string | boolean> | boolean | string[]);
+export declare type ValidationFn =
+    ((name?: string, store?: any, context?: any) => Promise<void | string | boolean> | boolean | string[]);
 
 export const DEFAULT_REDIRECT_KEY = 'default';

--- a/projects/ngx-permissions/src/lib/router/permissions-guard.service.spec.ts
+++ b/projects/ngx-permissions/src/lib/router/permissions-guard.service.spec.ts
@@ -23,6 +23,7 @@ describe('Permissions guard only', () => {
         spyOn(fakeRouter, 'navigate');
 
         service.addPermission('ADMIN');
+        service.addPermission('ADMIN_CONTEXT', (name, store, context) => context === true);
         permissionGuard = new NgxPermissionsGuard(service, rolesService, fakeRouter as Router);
     }));
 
@@ -38,6 +39,30 @@ describe('Permissions guard only', () => {
         }};
         (permissionGuard.canActivate(testRoute, {} as RouterStateSnapshot) as any).then((data) => {
             expect(data).toEqual(true);
+        });
+    }));
+
+    it ('should return true when only fulfils, with context', fakeAsync(() => {
+        testRoute = { data: {
+            permissions: {
+                only: 'ADMIN_CONTEXT',
+                context: true
+            }
+        }};
+        (permissionGuard.canActivate(testRoute, {} as RouterStateSnapshot) as any).then((data) => {
+            expect(data).toEqual(true);
+        });
+    }));
+
+    it ('should return false when only doesnt match, with context', fakeAsync(() => {
+        testRoute = { data: {
+            permissions: {
+                only: 'ADMIN_CONTEXT',
+                context: false
+            }
+        }};
+        (permissionGuard.canActivate(testRoute, {} as RouterStateSnapshot) as any).then((data) => {
+            expect(data).toEqual(false);
         });
     }));
 

--- a/projects/ngx-permissions/src/lib/router/permissions-guard.service.ts
+++ b/projects/ngx-permissions/src/lib/router/permissions-guard.service.ts
@@ -32,6 +32,7 @@ export interface NgxPermissionsData {
     only?: string | string[];
     except?: string | string[];
     redirectTo?: RedirectTo | RedirectToFn;
+    context?: any;
 }
 
 @Injectable()
@@ -79,12 +80,14 @@ export class NgxPermissionsGuard implements CanActivate, CanLoad, CanActivateChi
             ? permissions.except(route, state)
             : transformStringToArray(permissions.except);
         const redirectTo = permissions.redirectTo;
+        const context = permissions.context;
 
 
         return {
             only,
             except,
-            redirectTo
+            redirectTo,
+            context,
         };
     }
 
@@ -110,7 +113,7 @@ export class NgxPermissionsGuard implements CanActivate, CanLoad, CanActivateChi
                 .pipe(
                     mergeMap(permissionsExcept => {
                         return forkJoin([
-                            this.permissionsService.hasPermission(permissionsExcept),
+                            this.permissionsService.hasPermission(permissionsExcept, permissions.context),
                             this.rolesService.hasOnlyRoles(permissionsExcept)
                         ]).pipe(
                             tap(hasPermissions => {
@@ -141,7 +144,7 @@ export class NgxPermissionsGuard implements CanActivate, CanLoad, CanActivateChi
         }
 
         return Promise.all([
-            this.permissionsService.hasPermission(permissions.except),
+            this.permissionsService.hasPermission(permissions.except, permissions.context),
             this.rolesService.hasOnlyRoles(permissions.except)
         ]).then(([hasPermission, hasRoles]) => {
             if (hasPermission || hasRoles) {
@@ -223,7 +226,7 @@ export class NgxPermissionsGuard implements CanActivate, CanLoad, CanActivateChi
             .pipe(
                 mergeMap(permissionsOnly => {
                     return forkJoin([
-                        this.permissionsService.hasPermission(permissionsOnly),
+                        this.permissionsService.hasPermission(permissionsOnly, permissions.context),
                         this.rolesService.hasOnlyRoles(permissionsOnly)
                     ]).pipe(
                         tap(hasPermissions => {
@@ -295,7 +298,7 @@ export class NgxPermissionsGuard implements CanActivate, CanLoad, CanActivateChi
         };
 
         return Promise.all([
-            this.permissionsService.hasPermission(permissions.only),
+            this.permissionsService.hasPermission(permissions.only, permissions.context),
             this.rolesService.hasOnlyRoles(permissions.only)
         ]).then(([hasPermission, hasRole]) => {
             if (hasPermission || hasRole) {

--- a/projects/ngx-permissions/src/lib/router/permissions-guard.service.ts
+++ b/projects/ngx-permissions/src/lib/router/permissions-guard.service.ts
@@ -21,6 +21,7 @@ import {
     NgxPermissionsRouterData,
     NgxRedirectToNavigationParameters,
     OnlyFn,
+    ContextFn,
     RedirectTo,
     RedirectToFn
 } from '../model/permissions-router-data.model';
@@ -79,9 +80,10 @@ export class NgxPermissionsGuard implements CanActivate, CanLoad, CanActivateChi
         const except = isFunction<ExceptFn>(permissions.except)
             ? permissions.except(route, state)
             : transformStringToArray(permissions.except);
+        const context = isFunction<ContextFn>(permissions.context)
+            ? permissions.context(route, state)
+            : transformStringToArray(permissions.context);
         const redirectTo = permissions.redirectTo;
-        const context = permissions.context;
-
 
         return {
             only,

--- a/projects/ngx-permissions/src/lib/service/permissions.service.spec.ts
+++ b/projects/ngx-permissions/src/lib/service/permissions.service.spec.ts
@@ -168,6 +168,40 @@ describe('Permissions Service', () => {
         // });
     }));
 
+    it ('return true when role permission with context function return true', fakeAsync(() => {
+        expect(Object.keys(localService.getPermissions()).length).toEqual(0);
+        localService.addPermission(PermissionsNamesEnum.ADMIN as any, (name, store, context) => {
+            return context;
+        });
+        expect(Object.keys(localService.getPermissions()).length).toEqual(1);
+        localService.hasPermission('ADMIN', true).then((data) => {
+            expect(data).toEqual(true);
+        });
+
+        localService.addPermission(PermissionsNamesEnum.GUEST as any, (name, store, context) => {
+            return false && context;
+        });
+        expect(Object.keys(localService.getPermissions()).length).toEqual(2);
+        localService.hasPermission('GUEST', true).then((data) => {
+            expect(data).toEqual(false);
+        });
+
+        localService.addPermission('TEST1' as any, (name, store, context) => {
+            return Promise.resolve(context);
+        });
+        expect(Object.keys(localService.getPermissions()).length).toEqual(3);
+        localService.hasPermission('TEST1', true).then((data) => {
+            expect(data).toEqual(true);
+        });
+        localService.addPermission('TEST2' as any, (name, store, context) => {
+            return Promise.resolve(context);
+        });
+        expect(Object.keys(localService.getPermissions()).length).toEqual(4);
+        localService.hasPermission('TEST2', false).then((data) => {
+            expect(data).toEqual(false);
+        });
+    }));
+
     it ('return call function with name and store in array', fakeAsync(() => {
 
         localService.addPermission(['TEST11'] as any, (n, store) => {

--- a/projects/ngx-permissions/src/lib/service/permissions.service.ts
+++ b/projects/ngx-permissions/src/lib/service/permissions.service.ts
@@ -36,13 +36,13 @@ export class NgxPermissionsService {
         this.permissionsSource.next({});
     }
 
-    public hasPermission(permission: string | string[]): Promise<boolean> {
+    public hasPermission(permission: string | string[], context?: any): Promise<boolean> {
         if (!permission || (Array.isArray(permission) && permission.length === 0)) {
             return Promise.resolve(true);
         }
 
         permission = transformStringToArray(permission);
-        return this.hasArrayPermission(permission);
+        return this.hasArrayPermission(permission, context);
     }
 
     public loadPermissions(permissions: string[], validationFunction?: ValidationFn): void {
@@ -95,14 +95,14 @@ export class NgxPermissionsService {
         };
     }
 
-    private hasArrayPermission(permissions: string[]): Promise<boolean> {
+    private hasArrayPermission(permissions: string[], context?: any): Promise<boolean> {
         const promises: Observable<boolean>[] = permissions.map(key => {
             if (this.hasPermissionValidationFunction(key)) {
                 const validationFunction = this.permissionsSource.value[key].validationFunction;
                 const immutableValue = {...this.permissionsSource.value};
 
                 return of(null).pipe(
-                    map(() => validationFunction(key, immutableValue)),
+                    map(() => validationFunction(key, immutableValue, context)),
                     switchMap((promise: Promise<boolean> | boolean): ObservableInput<boolean> => isBoolean(promise) ?
                         of(promise as boolean) : promise as Promise<boolean>),
                     catchError(() => of(false))


### PR DESCRIPTION
As required by https://github.com/AlexKhymenko/ngx-permissions/issues/145 I've added the ability to pass a "context" object/any to the validation function, so it could return true or false based on the context where is used.

I've choose to put the context object as the third parameter because of retro-compatibility reasons:
```
export declare type ValidationFn =
    ((name?: string, store?: any, context?: any) => Promise<void | string | boolean> | boolean | string[]);
```
The resulting usage is this (in a real project, where the validation depends on the state of a report entity):
**Directive:**
```
        <ng-container *ngxPermissionsOnly="'reportEdit';context:report">
          <ion-button *ngSwitchCase="true" fill="clear" size="small" (click)="editReport()">
            <ion-icon name="document"></ion-icon>
            <div>Modifica Rapportino</div>
          </ion-button>
        </ng-container>

or

        <ng-template [ngxPermissionsOnly]="'reportEdit'" [ngxPermissionsOnlyContext]="report">
          <ion-button *ngSwitchCase="true" fill="clear" size="small" (click)="editReport()">
            <ion-icon name="document"></ion-icon>
            <div>Modifica Rapportino</div>
          </ion-button>
        </ng-template>
```
**Permission declaration:**
``` 
        this.permissionsService.addPermission('reportEdit', (name?: string, store?: any, report?: any) => {
            if (report) {
                return ((report.state == ReportState.Draft || report.state == ReportState.Sent) && !report.seen);
            }
        });
```
**Service hasPermission():**
``` 
this.permissionsService.hasPermission('reportEdit', report);
``` 

**Routing**
Here comes an issue, we need the report to do the permission validation, the right way would be to "resove" and have it available in the controller, too.
The problem is that the resolvers are evaluated after the guards (https://stackoverflow.com/questions/39190427/angular2-resolve-before-canactivate).
The only solution I can figure out is to create a custom validator that fetch the report, whom is fetched a second time in the controller (or resolver).
This is an example (not fully tested):

```
this.permissionsService.addPermission('reportEditById', async (name?: string, store?: any, reportId?: any) => {
	const report = awit this.reportService.get(reportId);
	if (report) {
		return ((report.state == ReportState.Draft || report.state == ReportState.Sent) && !report.seen);
	} 
});

let routes = [
  { path: '', 
    canActivate: [AuthGuard],
    children: [
      {
	  path: 'edit', 
          component: ReportEditComponent, 
          canActivate: [NgxPermissionsGuard],
          data: {
          permissions: {
           only: 'reportEditById',
           context:  (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
            const reportId = route.paramMap.get('id');           
            return reportId;
           },
           redirectTo: 'home'
         }
       }}
      ]
  }
]

```

**Note:**
I've added all the tests for the service, but omitted the ones for the directive and the router, I've tried to add some locally and it seems to work, the issue is that really I don't know what and how to test, and I feel I don't really know what I'm doing. I'd like to test what happen if the context changes, but I'm not confident with my testing skills.

