### PR TITLE
test: emit permissionsAuthorized from allow-stub

### DIFF
--- a/projects/ngx-permissions/src/lib/testing/permissions-allow.directive.stub.ts
+++ b/projects/ngx-permissions/src/lib/testing/permissions-allow.directive.stub.ts
@@ -39,7 +39,7 @@ export class NgxPermissionsAllowStubDirective implements OnInit {
     ngOnInit(): void {
         this.viewContainer.clear();
         this.viewContainer.createEmbeddedView(this.getAuthorizedTemplate());
-        this.permissionsUnauthorized.emit();
+        this.permissionsAuthorized.emit();
     }
 
     private getAuthorizedTemplate() {


### PR DESCRIPTION
In allow stub directive there was an emit of permissionsUnauthorized emitter.. looks to me like a mistake? 
